### PR TITLE
Fix count_cards logic and image generation

### DIFF
--- a/MTGDeck.py
+++ b/MTGDeck.py
@@ -135,8 +135,7 @@ class MagicDeck:
             print(card.get("name"))
             if card.get("name") == card_name:
                 return card.get("count")
-            else:
-                return 0
+        return 0
 
     def how_many_cards(self):
         total = 0
@@ -220,7 +219,7 @@ class MagicDeck:
         else:
             print("Error: No card images found")
 
-        return combined_image
+        return combined_image if card_images else None
 
 
     def combine_images(self, images, orientation, width=None, overlap=0):


### PR DESCRIPTION
## Summary
- bugfix: ensure `count_cards` loops through the deck correctly
- bugfix: avoid returning undefined variable in `generate_image`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687674c187d48328859fb566725e70b3