### PR TITLE
docs: fix typo in README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Follow these steps:
 1. Clone this repository to your local machine.
 2. Install the required dependencies by running `pip install -r requirements.txt`.
 3. Open the GUI. The main functionalities are:
-  - Ceate deck with custom name
+  - Create deck with custom name
   - Add/Remove cards to the created Deck (The deck is saved automatically)
   - If you have Decks already created you can load those decks and work with it
 


### PR DESCRIPTION
## Summary
- fix a typo in README usage instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687675b7d02883288194f9af22d5d1e2